### PR TITLE
Add the `SsspFamily` subclass of `Group`.

### DIFF
--- a/aiida_sssp/groups/__init__.py
+++ b/aiida_sssp/groups/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=undefined-variable
+from .family import *
+
+__all__ = (family.__all__,)

--- a/aiida_sssp/groups/family.py
+++ b/aiida_sssp/groups/family.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""Subclass of `Group` designed to represent a family of `UpfData` nodes."""
+import os
+
+from aiida.common import exceptions
+from aiida.common.lang import type_check
+from aiida.orm import Group, QueryBuilder
+from aiida.plugins import DataFactory
+
+__all__ = ('SsspFamily',)
+
+UpfData = DataFactory('upf')
+
+
+class SsspFamily(Group):
+    """Group to represent a pseudo potential family.
+
+    Each instance can only contain `UpfData` nodes and can only contain one for each element.
+    """
+
+    _node_types = (UpfData,)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the instance with an empty pseudo potential cache."""
+        super().__init__(*args, **kwargs)
+        self._pseudos = {}
+
+    def __repr__(self):
+        """Represent the instance for debugging purposes."""
+        return '{}<{}>'.format(self.__class__.__name__, self.pk or self.uuid)
+
+    def __str__(self):
+        """Represent the instance for human-readable purposes."""
+        return '{}<{}>'.format(self.__class__.__name__, self.label)
+
+    @classmethod
+    def create_from_folder(cls, dirpath, label, description=None):
+        """Create a new `SsspFamily` from the pseudo potentials contained in a directory.
+
+        :param dirpath: absolute path to the folder containing the UPF files.
+        :param label: the label to give to the `SsspFamily`, should not already exist
+        :param description: optional description to give to the family.
+        :return: new instance of `SsspFamily`
+        :raises ValueError: if a `SsspFamily` already exists with the given name
+        """
+        from aiida.common.exceptions import ParsingError
+
+        type_check(description, str, allow_none=True)
+
+        try:
+            cls.objects.get(label=label)
+        except exceptions.NotExistent:
+            family = SsspFamily(label=label)
+        else:
+            raise ValueError('the SsspFamily `{}` already exists'.format(label))
+
+        pseudos = []
+
+        if not os.path.isdir(dirpath):
+            raise ValueError('`{}` is not a directory'.format(dirpath))
+
+        for filename in os.listdir(dirpath):
+            filepath = os.path.join(dirpath, filename)
+
+            if not (filename.endswith('.upf') or filename.endswith('.UPF')):
+                continue
+
+            try:
+                pseudos.append(UpfData(filepath))
+            except ParsingError as exception:
+                raise ValueError('failed to parse `{}`: {}'.format(filepath, exception))
+
+        if len(pseudos) != len(set(pseudo.element for pseudo in pseudos)):
+            raise ValueError('directory `{}` contains pseudo potentials with duplicate elements'.format(dirpath))
+
+        if description is not None:
+            family.description = description
+
+        # Only store the `Group` and the `UpfData` nodes now, such that we don't have to worry about the clean up in
+        # the case that an exception is raised during creating them.
+        family.store()
+        family.add_nodes([upf.store() for upf in pseudos])
+
+        return family
+
+    def add_nodes(self, nodes):
+        """Add a node or a set of nodes to the family.
+
+        .. note: Each family instance can only contain a single `UpfData` for each element.
+
+        :param nodes: a single `Node` or a list of `Nodes` of type `SsspFamily._node_types`
+        :raises TypeError: if nodes are not an instance or list of instance of `SsspFamily._node_types`
+        :raises ValueError: if any of the elements of the nodes already exist in this family
+        """
+        if not isinstance(nodes, (list, tuple)):
+            nodes = [nodes]
+
+        if any([not isinstance(node, self._node_types) for node in nodes]):
+            raise TypeError('only nodes of type `{}` can be added'.format(self._node_types))
+
+        pseudos = {}
+
+        # Check for duplicates before adding any pseudo to the internal cache
+        for upf in nodes:
+            if upf.element in self.elements:
+                raise ValueError('element `{}` already present in this family'.format(upf.element))
+            pseudos[upf.element] = upf
+
+        self._pseudos.update(pseudos)
+
+        super().add_nodes(nodes)
+
+    @property
+    def elements(self):
+        """Return the list of elements of the `UpfData` nodes contained in this family.
+
+        :return: list of element symbols
+        """
+        if self._pseudos is None:
+            self._pseudos = {upf.element: upf for upf in self.nodes}
+
+        return list(self._pseudos.keys())
+
+    def get_pseudo(self, element):
+        """Return the `UpfData` for the given element.
+
+        :param element: the element for which to return the corresponding `UpfData` node.
+        :return: `UpfData` instance if it exists
+        :raises ValueError: if the family does not contain a `UpfData` for the given element
+        """
+        try:
+            pseudo = self._pseudos[element]
+        except KeyError:
+            builder = QueryBuilder().append(
+                SsspFamily, filters={'id': self.pk}, tag='group').append(
+                self._node_types, filters={'attributes.element': element}, with_group='group')  # yapf:disable
+
+            try:
+                pseudo = builder.one()[0]
+            except exceptions.MultipleObjectsError:
+                raise RuntimeError('family `{}` contains multiple pseudos for `{}`'.format(self.label, element))
+            except exceptions.NotExistent:
+                raise ValueError('family `{}` does not contain pseudo for element `{}`'.format(self.label, element))
+            else:
+                self._pseudos[element] = pseudo
+
+        return pseudo

--- a/setup.json
+++ b/setup.json
@@ -17,12 +17,15 @@
     "entry_points": {
         "console_scripts": [
             "aiida-sssp = aiida_sssp.cli:cmd_root"
+        ],
+        "aiida.groups": [
+            "sssp.family = aiida_sssp.groups.family:SsspFamily"
         ]
     },
     "python_requires": ">=3.5",
     "install_requires": [
-        "aiida-core>=1.0.0,<2.0.0",
-        "click~=7.1",
+        "aiida-core>=1.2.0,<2.0.0",
+        "click~=7.0",
         "click-completion~=0.5"
     ],
     "extras_require": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Configuration and fixtures for unit test suite."""
+import os
 import pytest
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
@@ -26,3 +27,27 @@ def run_cli_command():
         return result
 
     return _run_cli_command
+
+
+@pytest.fixture
+def filepath_fixtures():
+    """Return the absolute filepath to the directory containing the file `fixtures`."""
+    return os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+@pytest.fixture
+def filepath_pseudos(filepath_fixtures):
+    """Return the absolute filepath to the directory containing the pseudo potential files."""
+    return os.path.join(filepath_fixtures, 'pseudos')
+
+
+@pytest.fixture
+def get_upf_data(filepath_pseudos):
+    """Return `UpfData` for a given element."""
+
+    def _get_upf_data(element='He'):
+        from aiida.plugins import DataFactory
+        UpfData = DataFactory('upf')
+        return UpfData(os.path.join(filepath_pseudos, '{}.upf'.format(element)))
+
+    return _get_upf_data

--- a/tests/fixtures/pseudos/Ar.upf
+++ b/tests/fixtures/pseudos/Ar.upf
@@ -1,0 +1,14 @@
+<UPF version="2.0.1">
+    <PP_INFO>
+        <PP_INPUTFILE>
+        </PP_INPUTFILE>
+    </PP_INFO>
+    <PP_HEADER
+        generated="Manually created by S.P.Huber just for testing purposes"
+        author="sphuber"
+        date="200411"
+        comment=""
+        element="Ar"
+        pseudo_type="NC"
+    />
+</UPF>

--- a/tests/fixtures/pseudos/He.upf
+++ b/tests/fixtures/pseudos/He.upf
@@ -1,0 +1,14 @@
+<UPF version="2.0.1">
+    <PP_INFO>
+        <PP_INPUTFILE>
+        </PP_INPUTFILE>
+    </PP_INFO>
+    <PP_HEADER
+        generated="Manually created by S.P.Huber just for testing purposes"
+        author="sphuber"
+        date="200411"
+        comment=""
+        element="He"
+        pseudo_type="NC"
+    />
+</UPF>

--- a/tests/fixtures/pseudos/Ne.upf
+++ b/tests/fixtures/pseudos/Ne.upf
@@ -1,0 +1,14 @@
+<UPF version="2.0.1">
+    <PP_INFO>
+        <PP_INPUTFILE>
+        </PP_INPUTFILE>
+    </PP_INFO>
+    <PP_HEADER
+        generated="Manually created by S.P.Huber just for testing purposes"
+        author="sphuber"
+        date="200411"
+        comment=""
+        element="Ne"
+        pseudo_type="NC"
+    />
+</UPF>

--- a/tests/groups/test_family.py
+++ b/tests/groups/test_family.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Tests for the `SsspFamily` class."""
+import distutils.dir_util
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from aiida import orm
+from aiida_sssp.groups import SsspFamily
+
+
+def test_type_string(clear_database):
+    """Verify the `_type_string` class attribute is correctly set to the corresponding entry point name."""
+    assert SsspFamily._type_string == 'sssp.family'  # pylint: disable=protected-access
+
+
+def test_construct(clear_database):
+    """Test the construction of `SsspFamily` works."""
+    family = SsspFamily(label='SSSP').store()
+    assert isinstance(family, SsspFamily)
+
+    description = 'SSSP description'
+    family = SsspFamily(label='SSSP/v1.1', description=description).store()
+    assert isinstance(family, SsspFamily)
+    assert family.description == description
+
+
+def test_add_nodes(clear_database, get_upf_data):
+    """Test the `SsspFamily.add_nodes` method."""
+    upf_he = get_upf_data(element='He').store()
+    upf_ne = get_upf_data(element='Ne').store()
+    upf_ar = get_upf_data(element='Ar').store()
+    family = SsspFamily(label='SSSP').store()
+
+    with pytest.raises(TypeError):
+        family.add_nodes(orm.Data().store())
+
+    with pytest.raises(TypeError):
+        family.add_nodes([orm.Data().store(), orm.Data().store()])
+
+    with pytest.raises(TypeError):
+        family.add_nodes([upf_ar, orm.Data().store()])
+
+    assert family.count() == 0
+
+    family.add_nodes(upf_he)
+    assert family.count() == 1
+
+    # Check that adding a duplicate element raises, and that no extra nodes have been added.
+    with pytest.raises(ValueError):
+        family.add_nodes([upf_ar, upf_he, upf_ne])
+    assert family.count() == 1
+
+    family.add_nodes([upf_ar, upf_ne])
+    assert family.count() == 3
+
+
+def test_elements(clear_database, get_upf_data):
+    """Test the `SsspFamily.elements` property."""
+    upf_he = get_upf_data(element='He').store()
+    upf_ne = get_upf_data(element='Ne').store()
+    upf_ar = get_upf_data(element='Ar').store()
+    family = SsspFamily(label='SSSP').store()
+
+    family.add_nodes([upf_he, upf_ne, upf_ar])
+    assert family.count() == 3
+    assert sorted(family.elements) == ['Ar', 'He', 'Ne']
+
+
+def test_get_pseudo(clear_database, get_upf_data):
+    """Test the `SsspFamily.get_pseudo` property."""
+    upf_he = get_upf_data(element='He').store()
+    upf_ne = get_upf_data(element='Ne').store()
+    upf_ar = get_upf_data(element='Ar').store()
+    family = SsspFamily(label='SSSP').store()
+    family.add_nodes([upf_he, upf_ne, upf_ar])
+
+    with pytest.raises(ValueError) as exception:
+        family.get_pseudo('X')
+
+    assert 'family `{}` does not contain pseudo for element'.format(family.label) in str(exception.value)
+
+    element = 'He'
+    upf = family.get_pseudo(element)
+    assert isinstance(upf, orm.UpfData)
+    assert upf.element == element
+
+
+def test_create_from_folder(clear_database, filepath_pseudos):
+    """Test the `SsspFamily.create_from_folder` class method."""
+    label = 'SSSP'
+    family = SsspFamily.create_from_folder(filepath_pseudos, label)
+
+    assert isinstance(family, SsspFamily)
+    assert family.is_stored
+    assert family.count() == len(os.listdir(filepath_pseudos))
+    assert sorted(family.elements) == sorted([filename.rstrip('.upf') for filename in os.listdir(filepath_pseudos)])
+
+    # Files in `dirpath` not ending in `.upf` or `.UPF` should be ignored and so not raise
+    with tempfile.TemporaryDirectory() as dirpath:
+
+        # Copy over the actual pseudos and touch a file with a different file extension
+        distutils.dir_util.copy_tree(filepath_pseudos, dirpath)
+        open(os.path.join(dirpath, 'none_pseudo.txt'), 'a').close()
+
+        label = 'SSSP-clone'
+        family = SsspFamily.create_from_folder(dirpath, label)
+        assert family.is_stored
+        assert family.count() == len(os.listdir(filepath_pseudos))
+        assert sorted(family.elements) == sorted([filename.rstrip('.upf') for filename in os.listdir(filepath_pseudos)])
+
+    # Cannot create another family with the same label
+    with pytest.raises(ValueError):
+        SsspFamily.create_from_folder(filepath_pseudos, label)
+
+    with pytest.raises(TypeError) as exception:
+        SsspFamily.create_from_folder(filepath_pseudos, label, description=1)
+    assert 'Got object of type' in str(exception.value)
+
+
+def test_create_from_folder_invalid(clear_database, filepath_pseudos):
+    """Test the `SsspFamily.create_from_folder` class method for invalid inputs."""
+    label = 'SSSP'
+
+    with tempfile.TemporaryDirectory() as dirpath:
+
+        # Non-existing directory should raise
+        with pytest.raises(ValueError) as exception:
+            SsspFamily.create_from_folder(os.path.join(dirpath, 'non-existing'), label)
+
+        assert 'is not a directory' in str(exception.value)
+        assert SsspFamily.objects.count() == 0
+        assert orm.UpfData.objects.count() == 0
+
+        distutils.dir_util.copy_tree(filepath_pseudos, dirpath)
+
+        # Copy an existing pseudo to test that duplicate elements are not allowed
+        filename = os.listdir(dirpath)[0]
+        filepath = os.path.join(dirpath, filename)
+        shutil.copy(filepath, os.path.join(dirpath, filename[:-4] + '2.upf'))
+
+        with pytest.raises(ValueError) as exception:
+            SsspFamily.create_from_folder(dirpath, label)
+
+        assert 'contains pseudo potentials with duplicate elements' in str(exception.value)
+        assert SsspFamily.objects.count() == 0
+        assert orm.UpfData.objects.count() == 0
+
+        # Create a dummy file that does not have a valid UPF format
+        with open(filepath, 'w') as handle:
+            handle.write('invalid pseudo format')
+
+        with pytest.raises(ValueError) as exception:
+            SsspFamily.create_from_folder(dirpath, label)
+
+        assert 'failed to parse' in str(exception.value)
+        assert SsspFamily.objects.count() == 0
+        assert orm.UpfData.objects.count() == 0


### PR DESCRIPTION
Fixes #2 
Fixes #3 

Subclassing of the `Group` entity is a new feature that ships with
`aiida-core==1.2.0`. We use that here to create a subclass that can be
used to define a group of `UpfData` nodes. By making this an official
class, the creation, validation and manipulation of it is made a lot
easier. The logic to construct a family from a directory of pseudos can
now be implemented on this class, instead of having to provide a stand
alone function. Additionally, the validation can be implemented on the
class, for example to guarantee that there is only a single pseudo for
each element. Finally, the class implements an internal cache to make
the looking up of pseudos lazy and as efficient as possible.