### PR TITLE
Add the `aiida-sssp install` CLI command

### DIFF
--- a/aiida_sssp/cli/__init__.py
+++ b/aiida_sssp/cli/__init__.py
@@ -7,3 +7,4 @@ import click_completion
 click_completion.init()
 
 from .root import cmd_root
+from .install import cmd_install

--- a/aiida_sssp/cli/install.py
+++ b/aiida_sssp/cli/install.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Commands to install an `SsspFamily`."""
+import os
+import click
+
+from aiida.cmdline.utils import decorators, echo
+from .root import cmd_root
+from .utils import attempt, create_family_from_archive
+
+URL_BASE = 'https://archive.materialscloud.org/file/2018.0001'
+URL_MAPPING = {
+    ('1.1', 'PBE', 'efficiency'): ('v3/SSSP_efficiency_pseudos.tar.gz',),
+    ('1.1', 'PBE', 'precision'): ('v3/SSSP_precision_pseudos.tar.gz',)
+}  # yapf:disable
+
+
+@cmd_root.command('install')
+@click.option(
+    '-v', '--version', type=click.Choice(['1.1']), default='1.1', help='Select the version of the SSSP install.'
+)
+@click.option(
+    '-f', '--functional', type=click.Choice(['PBE']), default='PBE', help='Select the functional of the SSSP install.'
+)
+@click.option(
+    '-p',
+    '--protocol',
+    type=click.Choice(['efficiency', 'precision']),
+    default='precision',
+    help='Select the protocol of the SSSP install.'
+)
+@click.option('-t', '--traceback', is_flag=True, help='Include the stacktrace if an exception is encountered.')
+@decorators.with_dbenv()
+def cmd_install(version, functional, protocol, traceback):
+    """Install a version of the SSSP."""
+    import requests
+    from tempfile import NamedTemporaryFile
+    from aiida.common import exceptions
+    from aiida.orm import QueryBuilder
+    from aiida_sssp.groups import SsspFamily
+
+    label = '{}/{}/{}/{}'.format('SSSP', version, functional, protocol)
+    description = 'SSSP v{} {} {} installed through `aiida-sssp`'.format(version, functional, protocol)
+
+    try:
+        QueryBuilder().append(SsspFamily, filters={'label': label}).limit(1).one()
+    except exceptions.NotExistent:
+        pass
+    else:
+        echo.echo_critical('SSSP {} {} {} is already installed: {}'.format(version, functional, protocol, label))
+
+    try:
+        url_pseudos = os.path.join(URL_BASE, URL_MAPPING[(version, functional, protocol)][0])
+    except KeyError:
+        echo.echo_critical('No SSSP available for {} {} {}'.format(version, functional, protocol))
+
+    with NamedTemporaryFile(suffix='.tar.gz') as archive:
+
+        with attempt('downloading selected pseudo potentials... ', include_traceback=traceback):
+            response = requests.get(url_pseudos)
+            response.raise_for_status()
+            archive.write(response.content)
+
+        with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
+            family = create_family_from_archive(archive.name, label)
+
+        family.description = description
+        echo.echo_success('installed `{}` containing {} pseudo potentials'.format(label, family.count()))

--- a/aiida_sssp/cli/utils.py
+++ b/aiida_sssp/cli/utils.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Command line interface utilities."""
+from contextlib import contextmanager
+from aiida.cmdline.utils import echo
+
+__all__ = ('attempt', 'create_family_from_archive')
+
+
+@contextmanager
+def attempt(message, exception_types=Exception, include_traceback=False):
+    """Context manager to be used to wrap statements in CLI that can throw exceptions.
+
+    :param message: the message to print before yielding
+    :param include_traceback: boolean, if True, will also print traceback if an exception is caught
+    """
+    import sys
+    import traceback
+
+    echo.echo_info(message, nl=False)
+
+    try:
+        yield
+    except exception_types as exception:
+        echo.echo_highlight(' [FAILED]', color='error', bold=True)
+        message = str(exception)
+        if include_traceback:
+            message += '\n' + ''.join(traceback.format_exception(*sys.exc_info()))
+        echo.echo_critical(message)
+    else:
+        echo.echo_highlight(' [OK]', color='success', bold=True)
+
+
+def create_family_from_archive(filepath, label, fmt=None):
+    """Construct a new `SsspFamily` instance from a tar.gz archive.
+
+    .. warning:: the archive should not contain any subdirectories, but just the pseudos in UPF format.
+
+    :param filepath: absolute filepath to the .tar.gz archive containing the pseudo potentials.
+    :param label: the label for the new family
+    :param fmt: the format of the archive, if not specified will attempt to guess based on extension of `filepath`
+    :return: newly created `SsspFamily`
+    :raises OSError: if the archive could not be unpacked or pseudos in it could not be parsed into a `SsspFamily`
+    """
+    import shutil
+    import tempfile
+
+    from aiida_sssp.groups import SsspFamily
+
+    with tempfile.TemporaryDirectory() as dirpath:
+
+        try:
+            shutil.unpack_archive(filepath, dirpath, format=fmt)
+        except shutil.ReadError as exception:
+            raise OSError('failed to unpack the archive `{}`: {}'.format(filepath, exception))
+
+        try:
+            family = SsspFamily.create_from_folder(dirpath, label)
+        except ValueError as exception:
+            raise OSError('failed to parse pseudos from `{}`: {}'.format(dirpath, exception))
+
+    return family

--- a/setup.json
+++ b/setup.json
@@ -26,7 +26,8 @@
     "install_requires": [
         "aiida-core>=1.2.0,<2.0.0",
         "click~=7.0",
-        "click-completion~=0.5"
+        "click-completion~=0.5",
+        "requests~=2.20"
     ],
     "extras_require": {
         "tests": [

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Tests for the command `aiida-sssp install`."""
+from aiida import orm
+from aiida_sssp.cli import cmd_install
+
+
+def test_install(clear_db, run_cli_command):
+    """Test the `aiida-sssp install` command."""
+    from aiida_sssp.groups import SsspFamily
+
+    result = run_cli_command(cmd_install)
+    assert 'installed `SSSP/' in result.output
+    assert orm.QueryBuilder().append(SsspFamily).count() == 1
+
+    result = run_cli_command(cmd_install, raises=SystemExit)
+    assert 'is already installed' in result.output
+
+
+def test_install_fail(clear_db, run_cli_command):
+    """Test the `aiida-sssp install` command that should fail."""
+    # The efficiency archive currently includes an illegal sub-folder which is not supported yet
+    options = ['--protocol', 'efficiency']
+    result = run_cli_command(cmd_install, options, raises=SystemExit)
+    assert 'contains at least one entry that is not a file' in result.output

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Test the command line interface utilities."""
+import distutils.dir_util
+import enum
+import os
+import tarfile
+import tempfile
+
+import pytest
+
+from aiida_sssp.cli.utils import attempt, create_family_from_archive
+
+
+class ArchiveType(enum.IntEnum):
+    """Simple enum that determines what type of pseudo archive will be created."""
+
+    VALID = 0
+    INVALID_ARCHIVE_FORMAT = 1
+    INVALID_ARCHIVE_SUBFOLDER = 2
+    INVALID_UPF_FILE = 3
+
+
+@pytest.fixture
+def get_pseudo_archive(filepath_pseudos, request):
+    """Create a (potentially invalid) archive with pseudos."""
+    archive_type, exception, message = request.param
+    suffix = '.tar.gz'
+
+    with tempfile.TemporaryDirectory() as dirpath:
+
+        distutils.dir_util.copy_tree(filepath_pseudos, dirpath)
+
+        if archive_type == ArchiveType.INVALID_ARCHIVE_FORMAT:
+            suffix = '.txt'
+
+        if archive_type == ArchiveType.INVALID_ARCHIVE_SUBFOLDER:
+            os.makedirs(os.path.join(dirpath, 'subfolder'))
+
+        if archive_type == ArchiveType.INVALID_UPF_FILE:
+            open(os.path.join(dirpath, 'corrupt.upf'), 'a').close()
+
+        with tempfile.NamedTemporaryFile(suffix=suffix) as filepath_archive:
+
+            with tarfile.open(filepath_archive.name, 'w:gz') as tar:
+                tar.add(dirpath, arcname='.')
+
+            yield filepath_archive.name, exception, message
+
+
+@pytest.mark.parametrize(
+    'get_pseudo_archive', (
+        (ArchiveType.VALID, None, None),
+        (ArchiveType.INVALID_ARCHIVE_FORMAT, OSError, 'failed to unpack the archive'),
+        (ArchiveType.INVALID_ARCHIVE_SUBFOLDER, OSError, 'contains at least one entry that is not a file'),
+        (ArchiveType.INVALID_UPF_FILE, OSError, 'failed to parse'),
+    ),
+    indirect=True
+)
+def test_create_family_from_archive(clear_db, get_pseudo_archive):
+    """Test the `create_family_from_archive` utility function."""
+    from aiida_sssp.groups import SsspFamily
+
+    filepath_archive, exception, message = get_pseudo_archive
+
+    label = 'SSSP/0.0/LDA/extreme'
+
+    if exception is not None:
+        with pytest.raises(exception) as exception:
+            create_family_from_archive(filepath_archive, label)
+        assert message in str(exception.value)
+    else:
+        family = create_family_from_archive(filepath_archive, label)
+        assert isinstance(family, SsspFamily)
+        assert family.label == label
+        assert family.count() != 0
+
+
+def test_attempt_sucess(capsys):
+    """Test the `attempt` utility function."""
+    message = 'some message'
+
+    with attempt(message):
+        pass
+
+    captured = capsys.readouterr()
+    assert captured.out == 'Info: {} [OK]\n'.format(message)
+    assert captured.err == ''
+
+
+def test_attempt_exception(capsys):
+    """Test the `attempt` utility function when exception is raised."""
+    message = 'some message'
+    exception = 'run-time-error'
+
+    with pytest.raises(SystemExit):
+        with attempt(message):
+            raise RuntimeError(exception)
+
+    captured = capsys.readouterr()
+    assert captured.out == 'Info: {} [FAILED]\n'.format(message)
+    assert captured.err == 'Critical: {}\n'.format(exception)
+
+
+def test_attempt_exception_traceback(capsys):
+    """Test the `attempt` utility function when exception is raised and `include_traceback=True`."""
+    message = 'some message'
+    exception = 'run-time-error'
+
+    with pytest.raises(SystemExit):
+        with attempt(message, include_traceback=True):
+            raise RuntimeError(exception)
+
+    captured = capsys.readouterr()
+    assert captured.out == 'Info: {} [FAILED]\n'.format(message)
+    assert captured.err.startswith('Critical: {}\n'.format(exception))
+    assert 'Traceback' in captured.err

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
 """Configuration and fixtures for unit test suite."""
 import os
 import pytest
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
+
+
+@pytest.fixture
+def clear_db(clear_database_before_test):
+    """Alias for the `clear_database_before_test` fixture from `aiida-core`."""
+    yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,16 +20,24 @@ def run_cli_command():
     The call will raise if the command triggered an exception or the exit code returned is non-zero
     """
 
-    def _run_cli_command(command, options=None):
-        """Run the command and check the result."""
+    def _run_cli_command(command, options=None, raises=None):
+        """Run the command and check the result.
+
+        :param options: the list of command line options to pass to the command invocation
+        :param raises: optionally an exception class that is expected to be raised
+        """
         import traceback
         from click.testing import CliRunner
 
         runner = CliRunner()
         result = runner.invoke(command, options or [])
 
-        assert result.exception is None, ''.join(traceback.format_exception(*result.exc_info))
-        assert result.exit_code == 0, result.output
+        if raises is not None:
+            assert result.exception is not None, result.output
+            assert result.exit_code != 0
+        else:
+            assert result.exception is None, ''.join(traceback.format_exception(*result.exc_info))
+            assert result.exit_code == 0, result.output
 
         return result
 


### PR DESCRIPTION
Fixes #4 

This command will serve to automatically install a SSSP configuration by
downloading the corresponding archive from the Materials Cloud archive
and creating a new `SsspFamily` instance from it. Currently the
structure of the archives provided by the Materials Cloud are
inconsistent as some contain internal subdirectories and some don't. The
code currently does not fix this and will simply fail. Work is underway
to correct the actual archives on the Materials Cloud to respect a
strict consistent format.