### PR TITLE
Add the `SsspParameters` data plugin

### DIFF
--- a/aiida_sssp/data/__init__.py
+++ b/aiida_sssp/data/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=undefined-variable
+from .parameters import *
+
+__all__ = (parameters.__all__,)

--- a/aiida_sssp/data/parameters.py
+++ b/aiida_sssp/data/parameters.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Subclass of `Data` to represent parameters for a specific `SsspFamily`."""
+from aiida import orm
+from aiida.common.lang import type_check
+
+__all__ = ('SsspParameters',)
+
+
+class SsspParameters(orm.Data):
+    """Subclass of `Data` to represent parameters for a specific `SsspFamily`."""
+
+    KEY_FAMILY_LABEL = 'family_label'
+
+    def __init__(self, family, parameters, **kwargs):
+        """Construct a new instance of cutoff parameters for an `SsspFamily`.
+
+        The family has to be a stored instance of `SsspFamily`. The `parameters` should be a dictionary of elements, the
+        set of which matches exactly the set of elements in the family. Each element should provide a `cutoff` and a
+        `dual`.
+
+        :param family: a stored instance of `SsspFamily` to which the parameters should apply.
+        :param parameters: the dictionary with parameters of a given `SsspFamily`
+        """
+        from aiida_sssp.groups import SsspFamily
+        super().__init__(**kwargs)
+
+        if not isinstance(family, SsspFamily) or not family.is_stored:
+            raise TypeError('`family` is not a stored instance of `SsspFamily`.')
+
+        type_check(parameters, dict)
+
+        elements_family = set(family.elements)
+        elements_cutoff = set(parameters.keys())
+
+        if len(elements_family) > len(elements_cutoff):
+            elements_diff = elements_family.difference(elements_cutoff)
+            raise ValueError('parameters misses elements present in family: {}'.format(', '.join(elements_diff)))
+
+        if len(elements_family) < len(elements_cutoff):
+            elements_diff = elements_cutoff.difference(elements_family)
+            raise ValueError('parameters contains elements not present in family: {}'.format(', '.join(elements_diff)))
+
+        for element, values in parameters.items():
+            if 'cutoff' not in values:
+                raise ValueError('entry for element `{}` is missing the `cutoff` key'.format(element))
+
+            if 'dual' not in values:
+                raise ValueError('entry for element `{}` is missing the `dual` key'.format(element))
+
+            if not isinstance(values['cutoff'], (int, float)):
+                raise ValueError('`cutoff` for element `{}` is not of type int or float'.format(element))
+
+            if not isinstance(values['dual'], (int, float)):
+                raise ValueError('`dual` for element `{}` is not of type int or float'.format(element))
+
+        self.set_attribute_many(parameters)
+        self.set_attribute(self.KEY_FAMILY_LABEL, family.label)
+
+    def __repr__(self):
+        """Represent the instance for debugging purposes."""
+        return '{}<{}>'.format(self.__class__.__name__, self.pk or self.uuid)
+
+    def __str__(self):
+        """Represent the instance for human-readable purposes."""
+        return self.__repr__()
+
+    @property
+    def family_label(self):
+        """Return the label of the `SsspFamily` to which this parameters instance is associated.
+
+        :return: the label of the associated `SsspFamily`
+        """
+        return self.get_attribute(self.KEY_FAMILY_LABEL)
+
+    @property
+    def elements(self):
+        """Return the set of elements defined for this instance.
+
+        :return: set of elements
+        """
+        return set(self.attributes_keys()) - {self.KEY_FAMILY_LABEL}
+
+    def get_cutoffs(self, element):
+        """Return the recommended cutoffs for the given element.
+
+        :raises KeyError: if the element is not defined for this instance
+        """
+        try:
+            return self.get_attribute(element)
+        except AttributeError:
+            raise KeyError('element `{}` is not defined for `{}`'.format(element, self))

--- a/setup.json
+++ b/setup.json
@@ -18,6 +18,9 @@
         "console_scripts": [
             "aiida-sssp = aiida_sssp.cli:cmd_root"
         ],
+        "aiida.data": [
+            "sssp.parameters = aiida_sssp.data.parameters:SsspParameters"
+        ],
         "aiida.groups": [
             "sssp.family = aiida_sssp.groups.family:SsspFamily"
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,34 @@ def create_sssp_family(filepath_pseudos):
         return SsspFamily.create_from_folder(filepath_pseudos, label, description)
 
     return factory
+
+
+@pytest.fixture
+def create_sssp_parameters(create_sssp_family):
+    """Create an `SsspParameters` from the `tests/fixtures/pseudos` directory."""
+
+    def factory(family=None, parameters=None):
+        from aiida_sssp.data import SsspParameters
+
+        if family is None:
+            family = create_sssp_family()
+
+        if parameters is None:
+            parameters = {
+                'Ar': {
+                    'cutoff': 10.,
+                    'dual': 2
+                },
+                'He': {
+                    'cutoff': 20.,
+                    'dual': 4
+                },
+                'Ne': {
+                    'cutoff': 30.,
+                    'dual': 8
+                },
+            }
+
+        return SsspParameters(family, parameters)
+
+    return factory

--- a/tests/data/test_parameters.py
+++ b/tests/data/test_parameters.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Tests for the `SsspParameters` data class."""
+import pytest
+from aiida.orm import Group
+from aiida_sssp.data import SsspParameters
+from aiida_sssp.groups import SsspFamily
+
+SSSP_PARAMETERS = {
+    'Ar': {
+        'cutoff': 10.,
+        'dual': 2
+    },
+    'He': {
+        'cutoff': 20.,
+        'dual': 4
+    },
+    'Ne': {
+        'cutoff': 30.,
+        'dual': 8
+    },
+}
+
+
+def test_construction_fail(clear_db, create_sssp_family):
+    """Test the various construction arguments that should raise."""
+    family = create_sssp_family()
+
+    with pytest.raises(TypeError) as exception:
+        SsspParameters(Group(label='sssp'), {})
+    assert '`family` is not a stored instance of `SsspFamily`' in str(exception.value)
+
+    with pytest.raises(TypeError) as exception:
+        SsspParameters(SsspFamily(label='sssp'), {})
+    assert '`family` is not a stored instance of `SsspFamily`' in str(exception.value)
+
+    with pytest.raises(TypeError) as exception:
+        SsspParameters(family, [])
+    assert 'Got object of type' in str(exception.value)
+
+    with pytest.raises(ValueError) as exception:
+        SsspParameters(family, {'Ar': {}, 'He': {}})
+    assert 'parameters misses elements present in family' in str(exception.value)
+
+    with pytest.raises(ValueError) as exception:
+        SsspParameters(family, {'Ar': {}, 'He': {}, 'Ne': {}, 'Kr': {}})
+    assert 'parameters contains elements not present in family' in str(exception.value)
+
+    with pytest.raises(ValueError) as exception:
+        parameters = {'Ar': {'cutoff': 1, 'dual': 2}, 'He': {'cutoff': 1, 'dual': 2}, 'Ne': {'dual': 2}}
+        SsspParameters(family, parameters)
+    assert 'entry for element `Ne` is missing the `cutoff` key' in str(exception.value)
+
+    with pytest.raises(ValueError) as exception:
+        parameters = {'Ar': {'cutoff': 1, 'dual': 2}, 'He': {'cutoff': 1, 'dual': 2}, 'Ne': {'cutoff': 1}}
+        SsspParameters(family, parameters)
+    assert 'entry for element `Ne` is missing the `dual` key' in str(exception.value)
+
+    with pytest.raises(ValueError) as exception:
+        parameters = {'Ar': {'cutoff': 1, 'dual': 2}, 'He': {'cutoff': 1, 'dual': 2}, 'Ne': {'cutoff': 's', 'dual': 2}}
+        SsspParameters(family, parameters)
+    assert '`cutoff` for element `Ne` is not of type int or float' in str(exception.value)
+
+    with pytest.raises(ValueError) as exception:
+        parameters = {'Ar': {'cutoff': 1, 'dual': 2}, 'He': {'cutoff': 1, 'dual': 2}, 'Ne': {'cutoff': 1, 'dual': 's'}}
+        SsspParameters(family, parameters)
+    assert '`dual` for element `Ne` is not of type int or float' in str(exception.value)
+
+
+def test_construction(clear_db, create_sssp_parameters):
+    """Test the successful construction."""
+    node = create_sssp_parameters()
+    assert isinstance(node, SsspParameters)
+    assert node.uuid is not None
+
+    node.store()
+    assert node.pk is not None
+
+
+def test_family_label(clear_db, create_sssp_family, create_sssp_parameters):
+    """Test the `SsspParameters.family_label` property."""
+    family = create_sssp_family()
+    node = create_sssp_parameters(family)
+
+    assert node.family_label == family.label
+
+
+def test_elements(clear_db, create_sssp_parameters):
+    """Test the `SsspParameters.elements` property."""
+    node = create_sssp_parameters(parameters=SSSP_PARAMETERS)
+    assert sorted(SSSP_PARAMETERS.keys()) == sorted(node.elements)
+
+
+def test_get_cutoffs(clear_db, create_sssp_parameters):
+    """Test the `SsspParameters.get_cutoffs` method."""
+    node = create_sssp_parameters(parameters=SSSP_PARAMETERS)
+
+    with pytest.raises(KeyError):
+        node.get_cutoffs('Br')
+
+    for element, cutoffs in SSSP_PARAMETERS.items():
+        assert node.get_cutoffs(element) == cutoffs


### PR DESCRIPTION
Fixes #5 

This class is intended to host the parameters that are tied to a
particular instance of a `SsspFamily`. For now it only contains
information on the recommended cutoffs, the cutoff and dual, for each
element.