### PR TITLE
Add functionality to `SsspFamily` to retrieve data from `SsspParameters`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,3 +138,27 @@ def create_sssp_parameters(sssp_parameter_metadata, uuid):
         return SsspParameters(parameters, uuid)
 
     return factory
+
+
+@pytest.fixture
+def create_structure():
+    """Return a `StructureData` instance."""
+
+    def _create_structure(site_kind_names):
+        """Return a `StructureData` instance."""
+        import re
+        from aiida.plugins import DataFactory
+
+        StructureData = DataFactory('structure')
+
+        if not isinstance(site_kind_names, (list, tuple)):
+            site_kind_names = (site_kind_names,)
+
+        structure = StructureData(cell=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        for kind_name in site_kind_names:
+            structure.append_atom(name=kind_name, symbols=re.sub('[0-9]', '', kind_name), position=(0., 0., 0.))
+
+        return structure
+
+    return _create_structure


### PR DESCRIPTION
Fixes #13 

Specifically, the following methods are added:

  * `get_parameters_node`: get associated parameters node
  * `get_parameter`: get the contents of associated parameters node
  * `get_cutoffs`: get suggested cutoffs for set of elements

The latter is especially important to provide an easy interface to
retrieve the recommended wavefunction and charge density cutoffs for a
given set of elements. The `get_cutoffs` method therefore also accepts a
`StructureData` node instead of an explicit list of symbols.