### PR TITLE
Add the `aiida-sssp show` command

### DIFF
--- a/aiida_sssp/cli/__init__.py
+++ b/aiida_sssp/cli/__init__.py
@@ -9,3 +9,4 @@ click_completion.init()
 from .root import cmd_root
 from .install import cmd_install
 from .list import cmd_list
+from .show import cmd_show

--- a/aiida_sssp/cli/options.py
+++ b/aiida_sssp/cli/options.py
@@ -3,8 +3,41 @@
 import click
 
 from aiida.cmdline.params.options import OverridableOption
+from aiida.cmdline.params.types import DataParamType, GroupParamType
 
-__all__ = ('VERSION', 'FUNCTIONAL', 'PROTOCOL')
+__all__ = ('SSSP_FAMILY', 'VERSION', 'FUNCTIONAL', 'PROTOCOL')
+
+
+def default_sssp_family(ctx, param, identifier):  # pylint: disable=unused-argument
+    """Determine the default if no value is specified."""
+    from aiida.common import exceptions
+    from aiida.orm import QueryBuilder
+    from aiida_sssp.groups import SsspFamily
+
+    if identifier is not None:
+        return identifier
+
+    try:
+        return QueryBuilder().append(SsspFamily).first()[0]
+    except exceptions.NotExistent:
+        raise click.BadParameter('failed to automatically detect an SSSP family: install it with `aiida-sssp install`.')
+
+
+SSSP_FAMILY = OverridableOption(
+    '-F',
+    '--sssp-family',
+    type=GroupParamType(sub_classes=('aiida.groups:sssp.family',)),
+    required=False,
+    callback=default_sssp_family,
+    help='Select an SSSP family.'
+)
+
+STRUCTURE = OverridableOption(
+    '-S',
+    '--structure',
+    type=DataParamType(sub_classes=('aiida.data:structure',)),
+    help='Filter for elements of the given structure.'
+)
 
 VERSION = OverridableOption(
     '-v', '--version', type=click.STRING, required=False, help='Select the version of the SSSP configuration.'

--- a/aiida_sssp/cli/show.py
+++ b/aiida_sssp/cli/show.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Commands to show details of particular `SsspFamily` instances."""
+import click
+
+from aiida.common import exceptions
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
+from aiida.cmdline.utils import decorators, echo
+
+from .root import cmd_root
+from . import options
+
+
+@cmd_root.command('show')
+@click.argument('sssp_family', type=types.GroupParamType(sub_classes=('aiida.groups:sssp.family',)))
+@options.STRUCTURE()
+@options_core.RAW()
+@decorators.with_dbenv()
+def cmd_show(sssp_family, structure, raw):
+    """Show details of a particular SSSP_FAMILY."""
+    from tabulate import tabulate
+
+    rows = []
+
+    if structure:
+        iterator = sssp_family.get_pseudos(structure).values()
+    else:
+        iterator = sssp_family.nodes
+
+    try:
+        sssp_family.get_parameters_node()
+    except exceptions.NotExistent:
+        echo.echo_critical('{} does not have an associated `SsspParameters` node'.format(sssp_family))
+
+    for upf in iterator:
+        rows.append([upf.element, upf.filename] + list(sssp_family.get_cutoffs(elements=(upf.element,))))
+
+    headers = ['Element', 'Pseudo', 'Cutoff wfc', 'Cutoff rho']
+
+    if raw:
+        echo.echo(tabulate(sorted(rows), tablefmt='plain'))
+    else:
+        echo.echo(tabulate(sorted(rows), headers=headers))

--- a/aiida_sssp/groups/family.py
+++ b/aiida_sssp/groups/family.py
@@ -206,6 +206,16 @@ class SsspFamily(Group):
 
         return pseudo
 
+    def get_pseudos(self, structure):
+        """Return the mapping of kind names on `UpfData` for the given structure.
+
+        :param structure: the `StructureData` for which to return the corresponding `UpfData` mapping.
+        :return: dictionary of kind name mapping `UpfData`
+        :raises ValueError: if the family does not contain a `UpfData` for any of the elements of the given structure.
+        """
+        type_check(structure, StructureData)
+        return {kind.name: self.get_pseudo(kind.symbol) for kind in structure.kinds}
+
     def get_parameters_node(self):
         """Return the associated `SsspParameters` node if it exists.
 

--- a/setup.json
+++ b/setup.json
@@ -27,7 +27,7 @@
     },
     "python_requires": ">=3.5",
     "install_requires": [
-        "aiida-core>=1.2.0,<2.0.0",
+        "aiida-core~=1.2",
         "click~=7.0",
         "click-completion~=0.5",
         "requests~=2.20"

--- a/tests/cli/test_show.py
+++ b/tests/cli/test_show.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Tests for the command `aiida-sssp show`."""
+from aiida_sssp.cli import cmd_show
+
+
+def test_show(clear_db, run_cli_command, create_sssp_family):
+    """Test the `aiida-sssp show` command."""
+    result = run_cli_command(cmd_show, raises=SystemExit)
+    assert 'Missing argument' in result.output
+
+    family = create_sssp_family()
+    result = run_cli_command(cmd_show, [family.label], raises=SystemExit)
+    assert '{} does not have an associated `SsspParameters` node'.format(family) in result.output
+
+
+def test_show_raw(clear_db, run_cli_command, create_sssp_family, create_sssp_parameters):
+    """Test the `-r/--raw` option."""
+    family = create_sssp_family()
+    create_sssp_parameters(uuid=family.uuid).store()
+
+    for option in ['-r', '--raw']:
+        result = run_cli_command(cmd_show, [option, family.label])
+        assert len(result.output_lines) == len(family.nodes)
+
+
+def test_show_structure(clear_db, run_cli_command, create_sssp_family, create_sssp_parameters, create_structure):
+    """Test the `-s/--structure` option."""
+    family = create_sssp_family()
+    create_sssp_parameters(uuid=family.uuid).store()
+    structure = create_structure(site_kind_names=['Ar', 'He']).store()
+
+    for option in ['-S', '--structure']:
+        result = run_cli_command(cmd_show, [option, str(structure.pk), family.label])
+        assert 'Ar' in result.output
+        assert 'He' in result.output
+        assert 'Ne' not in result.output

--- a/tests/groups/test_family.py
+++ b/tests/groups/test_family.py
@@ -303,3 +303,31 @@ def test_get_cutoffs(clear_db, create_sssp_family, create_sssp_parameters, creat
 
     expected = parameters['Ne']
     assert family.get_cutoffs(structure=structure) == (expected['cutoff_wfc'], expected['cutoff_rho'])
+
+    # Try structure with multiple kinds with the same element
+    expected = parameters['He']
+    structure = create_structure(site_kind_names=['He1', 'He2'])
+    assert family.get_cutoffs(structure=structure) == (expected['cutoff_wfc'], expected['cutoff_rho'])
+
+
+def test_get_pseudos(clear_db, create_sssp_family, create_sssp_parameters, create_structure):
+    """Test the `SsspFamily.get_pseudos` method."""
+    family = create_sssp_family()
+
+    with pytest.raises(TypeError):
+        family.get_pseudos('Ar')
+
+    expected = {
+        'Ar': family.get_pseudo('Ar'),
+        'He': family.get_pseudo('He'),
+        'Ne': family.get_pseudo('Ne'),
+    }
+    structure = create_structure(site_kind_names=['Ar', 'He', 'Ne'])
+    assert family.get_pseudos(structure) == expected
+
+    expected = {
+        'Ar1': family.get_pseudo('Ar'),
+        'Ar2': family.get_pseudo('Ar'),
+    }
+    structure = create_structure(site_kind_names=['Ar1', 'Ar2'])
+    assert family.get_pseudos(structure) == expected

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-testpaths = tests
 filterwarnings =
     ignore::DeprecationWarning:frozendict:
     ignore::DeprecationWarning:sqlalchemy_utils:


### PR DESCRIPTION
Fixes #18 

This command shows detailed information about an `SsspFamily` instance.
Currently, it shows a table of all its pseudos with the filename and
recommended cutoffs. A `StructureData` can be passed as an option to
filter for just the elements of the given structure.