### PR TITLE
Add md5 of download files to `SsspFamily` description

### DIFF
--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -7,6 +7,7 @@ from aiida_sssp.cli import cmd_install
 
 def test_install(clear_db, run_cli_command):
     """Test the `aiida-sssp install` command."""
+    from aiida_sssp import __version__
     from aiida_sssp.data import SsspParameters
     from aiida_sssp.groups import SsspFamily
 
@@ -15,6 +16,10 @@ def test_install(clear_db, run_cli_command):
     assert orm.QueryBuilder().append(SsspFamily).count() == 1
 
     family = orm.QueryBuilder().append(SsspFamily).one()[0]
+    assert 'SSSP v1.1 PBE efficiency installed with aiida-sssp v{}'.format(__version__) in family.description
+    assert 'Pseudo metadata md5: 0d5d6c2c840383c7c4fc3a99b5dc3001' in family.description
+    assert 'Archive pseudos md5: 4803ce9fd1d84c777f87173cd4a2de33' in family.description
+
     parameters = family.get_parameters_node()
     assert isinstance(parameters, SsspParameters)
     assert parameters.family_uuid == family.uuid


### PR DESCRIPTION
Fixes #14 

When installing an `SsspFamily` through `aiida-sssp` the md5 checksum of
the download pseudo archive and pseudo metadata file is added to the
description. This might become useful in the future if inconsistencies
are suspected for a given family and we want to make sure that the
downloaded files were at least correct.

Note that the description of the family is not the ideal location to
store this information, as it is mutable, but currently, `Group`
instances in `aiida-core` do not support arbitrary attributes to be
stored. For the time being this is the best solution.