### PR TITLE
Update the base URL for the Materials Cloud Archive entry

### DIFF
--- a/aiida_sssp/cli/install.py
+++ b/aiida_sssp/cli/install.py
@@ -9,7 +9,7 @@ from .root import cmd_root
 from .utils import attempt, create_family_from_archive
 from . import options
 
-URL_BASE = 'https://archive.materialscloud.org/file/2018.0001/v4/'
+URL_BASE = 'https://legacy-archive.materialscloud.org/file/2018.0001/v4/'
 URL_MAPPING = {
     ('1.0', 'PBE', 'efficiency'): 'SSSP_1.0_PBE_efficiency',
     ('1.0', 'PBE', 'precision'): 'SSSP_1.0_PBE_precision',


### PR DESCRIPTION
Fixes #27 

On May 27th, the Materials Cloud Archive migrated to a new backend and
the current URL that we use for the SSSP archive entry is no longer
valid. The old URLs are temporarily still available under the hostname
`legacy-archive` but this is a temporary solution.