### PR TITLE
Generalize the `SsspFamily` to the `UpfFamily` group plugin

### DIFF
--- a/aiida_sssp/cli/install.py
+++ b/aiida_sssp/cli/install.py
@@ -79,7 +79,7 @@ def cmd_install(version, functional, protocol, traceback):
                 description += '\nPseudo metadata md5: {}'.format(md5_file(filepath_metadata))
 
         with attempt('unpacking archive and parsing pseudos... ', include_traceback=traceback):
-            family = create_family_from_archive(label, filepath_archive, filepath_metadata)
+            family = create_family_from_archive(SsspFamily, label, filepath_archive, filepath_metadata)
 
         family.description = description
         echo.echo_success('installed `{}` containing {} pseudo potentials'.format(label, family.count()))

--- a/aiida_sssp/cli/options.py
+++ b/aiida_sssp/cli/options.py
@@ -26,7 +26,7 @@ def default_sssp_family(ctx, param, identifier):  # pylint: disable=unused-argum
 SSSP_FAMILY = OverridableOption(
     '-F',
     '--sssp-family',
-    type=GroupParamType(sub_classes=('aiida.groups:sssp.family',)),
+    type=GroupParamType(sub_classes=('aiida.groups:sssp.family.sssp',)),
     required=False,
     callback=default_sssp_family,
     help='Select an SSSP family.'

--- a/aiida_sssp/cli/show.py
+++ b/aiida_sssp/cli/show.py
@@ -12,7 +12,7 @@ from . import options
 
 
 @cmd_root.command('show')
-@click.argument('sssp_family', type=types.GroupParamType(sub_classes=('aiida.groups:sssp.family',)))
+@click.argument('sssp_family', type=types.GroupParamType(sub_classes=('aiida.groups:sssp.family.sssp',)))
 @options.STRUCTURE()
 @options_core.RAW()
 @decorators.with_dbenv()

--- a/aiida_sssp/cli/utils.py
+++ b/aiida_sssp/cli/utils.py
@@ -30,22 +30,21 @@ def attempt(message, exception_types=Exception, include_traceback=False):
         echo.echo_highlight(' [OK]', color='success', bold=True)
 
 
-def create_family_from_archive(label, filepath_archive, filepath_metadata=None, fmt=None):
-    """Construct a new `SsspFamily` instance from a tar.gz archive.
+def create_family_from_archive(cls, label, filepath_archive, filepath_metadata=None, fmt=None):
+    """Construct a new pseudo family instance from a tar.gz archive.
 
     .. warning:: the archive should not contain any subdirectories, but just the pseudos in UPF format.
 
+    :param cls: the class to use, e.g., `UpfFamily` or `SsspFamily`
     :param label: the label for the new family
     :param filepath: absolute filepath to the .tar.gz archive containing the pseudo potentials.
     :param filepath: optional absolute filepath to the .json file containing the pseudo potentials metadata.
     :param fmt: the format of the archive, if not specified will attempt to guess based on extension of `filepath`
-    :return: newly created `SsspFamily`
-    :raises OSError: if the archive could not be unpacked or pseudos in it could not be parsed into a `SsspFamily`
+    :return: newly created family
+    :raises OSError: if the archive could not be unpacked or pseudos in it could not be parsed into a family
     """
     import shutil
     import tempfile
-
-    from aiida_sssp.groups import SsspFamily
 
     with tempfile.TemporaryDirectory() as dirpath:
 
@@ -55,7 +54,7 @@ def create_family_from_archive(label, filepath_archive, filepath_metadata=None, 
             raise OSError('failed to unpack the archive `{}`: {}'.format(filepath_archive, exception))
 
         try:
-            family = SsspFamily.create_from_folder(dirpath, label, filepath_parameters=filepath_metadata)
+            family = cls.create_from_folder(dirpath, label, filepath_parameters=filepath_metadata)
         except ValueError as exception:
             raise OSError('failed to parse pseudos from `{}`: {}'.format(dirpath, exception))
 

--- a/aiida_sssp/groups/__init__.py
+++ b/aiida_sssp/groups/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable
-from .family import *
+from .sssp import *
+from .upf import *
 
-__all__ = (family.__all__,)
+__all__ = (sssp.__all__ + upf.__all__)

--- a/aiida_sssp/groups/sssp.py
+++ b/aiida_sssp/groups/sssp.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Subclass of `Group` designed to represent an SSSP configuration."""
+from collections import namedtuple
+from typing import Sequence
+
+from .upf import UpfFamily
+
+__all__ = ('SsspConfiguration', 'SsspFamily')
+
+SsspConfiguration = namedtuple('SsspConfiguration', ['version', 'functional', 'protocol'])
+
+
+class SsspFamily(UpfFamily):
+    """Subclass of `Group` designed to represent an SSSP configuration.
+
+    The `SsspFamily` is essentially a `UpfFamily` with some additional constraints. It can only be used to contain the
+    pseudo potentials and corresponding metadata of an official SSSP configuration.
+    """
+
+    label_template = 'SSSP/{version}/{functional}/{protocol}'
+    default_configuration = SsspConfiguration('1.1', 'PBE', 'efficiency')
+    valid_configurations = (
+        SsspConfiguration('1.0', 'PBE', 'efficiency'),
+        SsspConfiguration('1.0', 'PBE', 'precision'),
+        SsspConfiguration('1.1', 'PBE', 'efficiency'),
+        SsspConfiguration('1.1', 'PBE', 'precision'),
+        SsspConfiguration('1.1', 'PBEsol', 'efficiency'),
+        SsspConfiguration('1.1', 'PBEsol', 'precision'),
+    )
+
+    @classmethod
+    def get_valid_labels(cls) -> Sequence[str]:
+        """Return the tuple of labels of all valid SSSP configurations."""
+        return tuple(cls.format_configuration_label(configuration) for configuration in cls.valid_configurations)
+
+    @classmethod
+    def format_configuration_label(cls, configuration: SsspConfiguration) -> str:
+        """Format a label for an `SsspFamily` with the required syntax.
+
+        :param configuration: the SSSP configuration
+        :return: label
+        """
+        return cls.label_template.format(
+            version=configuration.version, functional=configuration.functional, protocol=configuration.protocol
+        )
+
+    def __init__(self, label=None, **kwargs):
+        """Construct a new instance, validating that the label matches the required format."""
+        if label not in self.get_valid_labels():
+            raise ValueError('the label `{}` is not a valid SSSP configuration label.'.format(label))
+
+        super().__init__(label=label, **kwargs)

--- a/aiida_sssp/groups/upf.py
+++ b/aiida_sssp/groups/upf.py
@@ -7,14 +7,14 @@ from aiida.common.lang import type_check
 from aiida.orm import Group, QueryBuilder
 from aiida.plugins import DataFactory
 
-__all__ = ('SsspFamily',)
+__all__ = ('UpfFamily',)
 
 UpfData = DataFactory('upf')
 SsspParameters = DataFactory('sssp.parameters')
 StructureData = DataFactory('structure')
 
 
-class SsspFamily(Group):
+class UpfFamily(Group):
     """Group to represent a pseudo potential family.
 
     Each instance can only contain `UpfData` nodes and can only contain one for each element.
@@ -97,26 +97,26 @@ class SsspFamily(Group):
 
     @classmethod
     def create_from_folder(cls, dirpath, label, description=None, filepath_parameters=None):
-        """Create a new `SsspFamily` from the pseudo potentials contained in a directory.
+        """Create a new `UpfFamily` from the pseudo potentials contained in a directory.
 
         .. note:: the directory pointed to by `dirpath` should only contain UPF files. If it contains any folders or any
             of the files cannot be parsed as valid UPF, the method will raise a `ValueError`.
 
         :param dirpath: absolute path to the folder containing the UPF files.
-        :param label: the label to give to the `SsspFamily`, should not already exist
+        :param label: the label to give to the `UpfFamily`, should not already exist
         :param description: optional description to give to the family.
         :param filepath_parameters: a filelike object or filepath to a file containing metadata for `SsspParameters`.
-        :return: new stored instance of `SsspFamily`
-        :raises ValueError: if a `SsspFamily` already exists with the given name
+        :return: new stored instance of `UpfFamily`
+        :raises ValueError: if a `UpfFamily` already exists with the given name
         """
         type_check(description, str, allow_none=True)
 
         try:
             cls.objects.get(label=label)
         except exceptions.NotExistent:
-            family = SsspFamily(label=label)
+            family = cls(label=label)
         else:
-            raise ValueError('the SsspFamily `{}` already exists'.format(label))
+            raise ValueError('the UpfFamily `{}` already exists'.format(label))
 
         pseudos = cls.parse_pseudos_from_directory(dirpath)
 
@@ -140,8 +140,8 @@ class SsspFamily(Group):
 
         .. note: Each family instance can only contain a single `UpfData` for each element.
 
-        :param nodes: a single `Node` or a list of `Nodes` of type `SsspFamily._node_types`
-        :raises TypeError: if nodes are not an instance or list of instance of `SsspFamily._node_types`
+        :param nodes: a single `Node` or a list of `Nodes` of type `UpfFamily._node_types`
+        :raises TypeError: if nodes are not an instance or list of instance of `UpfFamily._node_types`
         :raises ValueError: if any of the elements of the nodes already exist in this family
         """
         if not isinstance(nodes, (list, tuple)):
@@ -192,7 +192,7 @@ class SsspFamily(Group):
             pseudo = self.pseudos[element]
         except KeyError:
             builder = QueryBuilder().append(
-                SsspFamily, filters={'id': self.pk}, tag='group').append(
+                UpfFamily, filters={'id': self.pk}, tag='group').append(
                 self._node_types, filters={'attributes.element': element}, with_group='group')  # yapf:disable
 
             try:

--- a/setup.json
+++ b/setup.json
@@ -22,7 +22,8 @@
             "sssp.parameters = aiida_sssp.data.parameters:SsspParameters"
         ],
         "aiida.groups": [
-            "sssp.family = aiida_sssp.groups.family:SsspFamily"
+            "sssp.family.upf = aiida_sssp.groups.upf:UpfFamily",
+            "sssp.family.sssp = aiida_sssp.groups.sssp:SsspFamily"
         ]
     },
     "python_requires": ">=3.5",

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -60,7 +60,7 @@ def get_pseudo_archive(filepath_pseudos, request):
 def test_create_family_from_archive(clear_db, get_pseudo_archive, sssp_parameter_filepath):
     """Test the `create_family_from_archive` utility function."""
     from aiida_sssp.data import SsspParameters
-    from aiida_sssp.groups import SsspFamily
+    from aiida_sssp.groups import UpfFamily
 
     filepath_archive, exception, message = get_pseudo_archive
 
@@ -68,18 +68,18 @@ def test_create_family_from_archive(clear_db, get_pseudo_archive, sssp_parameter
 
     if exception is not None:
         with pytest.raises(exception) as exception:
-            create_family_from_archive(label, filepath_archive)
+            create_family_from_archive(UpfFamily, label, filepath_archive)
         assert message in str(exception.value)
         return
 
-    family = create_family_from_archive(label, filepath_archive)
-    assert isinstance(family, SsspFamily)
+    family = create_family_from_archive(UpfFamily, label, filepath_archive)
+    assert isinstance(family, UpfFamily)
     assert family.label == label
     assert family.count() != 0
 
     label = 'SSSP/1.0/LDA/extreme'
-    family = create_family_from_archive(label, filepath_archive, sssp_parameter_filepath)
-    assert isinstance(family, SsspFamily)
+    family = create_family_from_archive(UpfFamily, label, filepath_archive, sssp_parameter_filepath)
+    assert isinstance(family, UpfFamily)
     assert family.label == label
     assert family.count() != 0
     assert isinstance(family.get_parameters_node(), SsspParameters)

--- a/tests/groups/test_sssp.py
+++ b/tests/groups/test_sssp.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument,pointless-statement
+"""Tests for the `SsspFamily` class."""
+import pytest
+
+from aiida_sssp.groups import SsspConfiguration, SsspFamily
+
+
+def test_default_configuration():
+    """Test the `SsspFamily.default_configuration` class attribute."""
+    assert isinstance(SsspFamily.default_configuration, SsspConfiguration)
+
+
+def test_valid_configurations():
+    """Test the `SsspFamily.valid_configurations` class attribute."""
+    valid_configurations = SsspFamily.valid_configurations
+    assert isinstance(valid_configurations, tuple)
+
+    for entry in valid_configurations:
+        assert isinstance(entry, SsspConfiguration)
+
+
+def test_get_valid_labels():
+    """Test the `SsspFamily.get_valid_labels` class method."""
+    valid_labels = SsspFamily.get_valid_labels()
+    assert isinstance(valid_labels, tuple)
+
+    for entry in valid_labels:
+        assert isinstance(entry, str)
+
+
+def test_format_configuration_label():
+    """Test the `SsspFamily.format_configuration_label` class method."""
+    configuration = SsspConfiguration(1.1, 'PBE', 'efficiency')
+    assert SsspFamily.format_configuration_label(configuration) == 'SSSP/1.1/PBE/efficiency'
+
+
+def test_constructor():
+    """Test that the `SsspFamily` constructor validates the label."""
+    with pytest.raises(ValueError, match=r'the label `.*` is not a valid SSSP configuration label'):
+        SsspFamily()
+
+    with pytest.raises(ValueError, match=r'the label `.*` is not a valid SSSP configuration label'):
+        SsspFamily(label='SSSP_1.1_PBE_efficiency')
+
+    label = SsspFamily.format_configuration_label(SsspFamily.default_configuration)
+    family = SsspFamily(label=label)
+    assert isinstance(family, SsspFamily)

--- a/tests/groups/test_upf.py
+++ b/tests/groups/test_upf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=unused-argument,pointless-statement
-"""Tests for the `SsspFamily` class."""
+"""Tests for the `UpfFamily` class."""
 import copy
 import distutils.dir_util
 import os
@@ -13,42 +13,42 @@ from aiida import orm
 from aiida.common import exceptions
 
 from aiida_sssp.data import SsspParameters
-from aiida_sssp.groups import SsspFamily
+from aiida_sssp.groups import UpfFamily
 
 
 def test_type_string(clear_db):
     """Verify the `_type_string` class attribute is correctly set to the corresponding entry point name."""
-    assert SsspFamily._type_string == 'sssp.family'  # pylint: disable=protected-access
+    assert UpfFamily._type_string == 'sssp.family.upf'  # pylint: disable=protected-access
 
 
 def test_construct(clear_db):
-    """Test the construction of `SsspFamily` works."""
-    family = SsspFamily(label='SSSP').store()
-    assert isinstance(family, SsspFamily)
+    """Test the construction of `UpfFamily` works."""
+    family = UpfFamily(label='SSSP').store()
+    assert isinstance(family, UpfFamily)
 
     description = 'SSSP description'
-    family = SsspFamily(label='SSSP/v1.1', description=description).store()
-    assert isinstance(family, SsspFamily)
+    family = UpfFamily(label='SSSP/v1.1', description=description).store()
+    assert isinstance(family, UpfFamily)
     assert family.description == description
 
 
 def test_load(clear_db):
-    """Test that loading of a `SsspFamily` through `load_group` works."""
-    family = SsspFamily(label='SSSP').store()
-    assert isinstance(family, SsspFamily)
+    """Test that loading of a `UpfFamily` through `load_group` works."""
+    family = UpfFamily(label='SSSP').store()
+    assert isinstance(family, UpfFamily)
 
     loaded = orm.load_group(family.pk)
-    assert isinstance(family, SsspFamily)
+    assert isinstance(family, UpfFamily)
     assert loaded.uuid == family.uuid
     assert loaded.elements == family.elements
 
 
 def test_add_nodes(clear_db, get_upf_data):
-    """Test the `SsspFamily.add_nodes` method."""
+    """Test the `UpfFamily.add_nodes` method."""
     upf_he = get_upf_data(element='He').store()
     upf_ne = get_upf_data(element='Ne').store()
     upf_ar = get_upf_data(element='Ar').store()
-    family = SsspFamily(label='SSSP').store()
+    family = UpfFamily(label='SSSP').store()
 
     with pytest.raises(TypeError):
         family.add_nodes(orm.Data().store())
@@ -74,11 +74,11 @@ def test_add_nodes(clear_db, get_upf_data):
 
 
 def test_elements(clear_db, get_upf_data):
-    """Test the `SsspFamily.elements` property."""
+    """Test the `UpfFamily.elements` property."""
     upf_he = get_upf_data(element='He').store()
     upf_ne = get_upf_data(element='Ne').store()
     upf_ar = get_upf_data(element='Ar').store()
-    family = SsspFamily(label='SSSP').store()
+    family = UpfFamily(label='SSSP').store()
 
     family.add_nodes([upf_he, upf_ne, upf_ar])
     assert family.count() == 3
@@ -86,11 +86,11 @@ def test_elements(clear_db, get_upf_data):
 
 
 def test_get_pseudo(clear_db, get_upf_data):
-    """Test the `SsspFamily.get_pseudo` property."""
+    """Test the `UpfFamily.get_pseudo` property."""
     upf_he = get_upf_data(element='He').store()
     upf_ne = get_upf_data(element='Ne').store()
     upf_ar = get_upf_data(element='Ar').store()
-    family = SsspFamily(label='SSSP').store()
+    family = UpfFamily(label='SSSP').store()
     family.add_nodes([upf_he, upf_ne, upf_ar])
 
     with pytest.raises(ValueError) as exception:
@@ -105,12 +105,12 @@ def test_get_pseudo(clear_db, get_upf_data):
 
 
 def test_validate_parameters(clear_db, create_sssp_family, create_sssp_parameters):
-    """Test the `SsspFamily.validate_parameters` class method."""
+    """Test the `UpfFamily.validate_parameters` class method."""
     family = create_sssp_family()
     parameters = create_sssp_parameters()
     metadata = parameters.get_metadata()
 
-    SsspFamily.validate_parameters(list(family.nodes), parameters)
+    UpfFamily.validate_parameters(list(family.nodes), parameters)
 
     # Incorrect filename
     incorrect = copy.deepcopy(metadata['Ar'])
@@ -118,7 +118,7 @@ def test_validate_parameters(clear_db, create_sssp_family, create_sssp_parameter
     parameters.set_attribute('Ar', incorrect)
 
     with pytest.raises(ValueError) as exception:
-        SsspFamily.validate_parameters(list(family.nodes), parameters)
+        UpfFamily.validate_parameters(list(family.nodes), parameters)
 
     assert 'inconsistent `filename` for element `Ar`' in str(exception.value)
 
@@ -128,42 +128,42 @@ def test_validate_parameters(clear_db, create_sssp_family, create_sssp_parameter
     parameters.set_attribute('Ar', incorrect)
 
     with pytest.raises(ValueError) as exception:
-        SsspFamily.validate_parameters(list(family.nodes), parameters)
+        UpfFamily.validate_parameters(list(family.nodes), parameters)
 
     assert 'inconsistent `md5` for element `Ar`' in str(exception.value)
 
 
 def test_create_from_folder(clear_db, filepath_pseudos):
-    """Test the `SsspFamily.create_from_folder` class method."""
+    """Test the `UpfFamily.create_from_folder` class method."""
     label = 'SSSP'
-    family = SsspFamily.create_from_folder(filepath_pseudos, label)
+    family = UpfFamily.create_from_folder(filepath_pseudos, label)
 
-    assert isinstance(family, SsspFamily)
+    assert isinstance(family, UpfFamily)
     assert family.is_stored
     assert family.count() == len(os.listdir(filepath_pseudos))
     assert sorted(family.elements) == sorted([filename.rstrip('.upf') for filename in os.listdir(filepath_pseudos)])
 
     # Cannot create another family with the same label
     with pytest.raises(ValueError):
-        SsspFamily.create_from_folder(filepath_pseudos, label)
+        UpfFamily.create_from_folder(filepath_pseudos, label)
 
     with pytest.raises(TypeError) as exception:
-        SsspFamily.create_from_folder(filepath_pseudos, label, description=1)
+        UpfFamily.create_from_folder(filepath_pseudos, label, description=1)
     assert 'Got object of type' in str(exception.value)
 
 
 def test_create_from_folder_invalid(clear_db, filepath_pseudos):
-    """Test the `SsspFamily.create_from_folder` class method for invalid inputs."""
+    """Test the `UpfFamily.create_from_folder` class method for invalid inputs."""
     label = 'SSSP'
 
     with tempfile.TemporaryDirectory() as dirpath:
 
         # Non-existing directory should raise
         with pytest.raises(ValueError) as exception:
-            SsspFamily.create_from_folder(os.path.join(dirpath, 'non-existing'), label)
+            UpfFamily.create_from_folder(os.path.join(dirpath, 'non-existing'), label)
 
         assert 'is not a directory' in str(exception.value)
-        assert SsspFamily.objects.count() == 0
+        assert UpfFamily.objects.count() == 0
         assert orm.UpfData.objects.count() == 0
 
         distutils.dir_util.copy_tree(filepath_pseudos, dirpath)
@@ -174,10 +174,10 @@ def test_create_from_folder_invalid(clear_db, filepath_pseudos):
         shutil.copy(filepath, os.path.join(dirpath, filename[:-4] + '2.upf'))
 
         with pytest.raises(ValueError) as exception:
-            SsspFamily.create_from_folder(dirpath, label)
+            UpfFamily.create_from_folder(dirpath, label)
 
         assert 'contains pseudo potentials with duplicate elements' in str(exception.value)
-        assert SsspFamily.objects.count() == 0
+        assert UpfFamily.objects.count() == 0
         assert orm.UpfData.objects.count() == 0
 
         # Create an empty folder in the pseudo directory, which is not allowed
@@ -185,10 +185,10 @@ def test_create_from_folder_invalid(clear_db, filepath_pseudos):
         os.makedirs(dirpath_sub)
 
         with pytest.raises(ValueError) as exception:
-            SsspFamily.create_from_folder(dirpath, label)
+            UpfFamily.create_from_folder(dirpath, label)
 
         assert 'contains at least one entry that is not a file' in str(exception.value)
-        assert SsspFamily.objects.count() == 0
+        assert UpfFamily.objects.count() == 0
         assert orm.UpfData.objects.count() == 0
         os.rmdir(dirpath_sub)
 
@@ -197,21 +197,21 @@ def test_create_from_folder_invalid(clear_db, filepath_pseudos):
             handle.write('invalid pseudo format')
 
         with pytest.raises(ValueError) as exception:
-            SsspFamily.create_from_folder(dirpath, label)
+            UpfFamily.create_from_folder(dirpath, label)
 
         assert 'failed to parse' in str(exception.value)
-        assert SsspFamily.objects.count() == 0
+        assert UpfFamily.objects.count() == 0
         assert orm.UpfData.objects.count() == 0
 
 
 def test_create_from_folder_with_parameters(clear_db, filepath_pseudos, sssp_parameter_filepath):
-    """Test the `SsspFamily.create_from_folder` class method when passing a file with pseudo metadata."""
+    """Test the `UpfFamily.create_from_folder` class method when passing a file with pseudo metadata."""
     with pytest.raises(TypeError):
-        SsspFamily.create_from_folder(filepath_pseudos, 'SSSP', filepath_parameters={})
+        UpfFamily.create_from_folder(filepath_pseudos, 'SSSP', filepath_parameters={})
 
     # Test directly from filepath
-    family = SsspFamily.create_from_folder(filepath_pseudos, 'SSSP/1.0', filepath_parameters=sssp_parameter_filepath)
-    assert isinstance(family, SsspFamily)
+    family = UpfFamily.create_from_folder(filepath_pseudos, 'SSSP/1.0', filepath_parameters=sssp_parameter_filepath)
+    assert isinstance(family, UpfFamily)
     assert family.is_stored
 
     parameters = family.get_parameters_node()
@@ -219,8 +219,8 @@ def test_create_from_folder_with_parameters(clear_db, filepath_pseudos, sssp_par
 
     # Test from filelike object
     with open(sssp_parameter_filepath) as handle:
-        family = SsspFamily.create_from_folder(filepath_pseudos, 'SSSP/1.1', filepath_parameters=handle)
-        assert isinstance(family, SsspFamily)
+        family = UpfFamily.create_from_folder(filepath_pseudos, 'SSSP/1.1', filepath_parameters=handle)
+        assert isinstance(family, UpfFamily)
         assert family.is_stored
 
         parameters = family.get_parameters_node()
@@ -228,7 +228,7 @@ def test_create_from_folder_with_parameters(clear_db, filepath_pseudos, sssp_par
 
 
 def test_get_parameters_node(clear_db, create_sssp_family, create_sssp_parameters):
-    """Test the `SsspFamily.get_parameters_node` method."""
+    """Test the `UpfFamily.get_parameters_node` method."""
     family = create_sssp_family()
 
     with pytest.raises(exceptions.NotExistent):
@@ -241,7 +241,7 @@ def test_get_parameters_node(clear_db, create_sssp_family, create_sssp_parameter
 
 
 def test_parameters(clear_db, create_sssp_family, create_sssp_parameters):
-    """Test the `SsspFamily.parameters` property."""
+    """Test the `UpfFamily.parameters` property."""
     family = create_sssp_family()
 
     with pytest.raises(exceptions.NotExistent):
@@ -254,7 +254,7 @@ def test_parameters(clear_db, create_sssp_family, create_sssp_parameters):
 
 
 def test_get_parameter(clear_db, create_sssp_family, create_sssp_parameters, sssp_parameter_metadata):
-    """Test the `SsspFamily.get_parameter` method."""
+    """Test the `UpfFamily.get_parameter` method."""
     family = create_sssp_family()
 
     with pytest.raises(exceptions.NotExistent):
@@ -277,7 +277,7 @@ def test_get_parameter(clear_db, create_sssp_family, create_sssp_parameters, sss
 
 
 def test_get_cutoffs(clear_db, create_sssp_family, create_sssp_parameters, create_structure):
-    """Test the `SsspFamily.get_cutoffs` method."""
+    """Test the `UpfFamily.get_cutoffs` method."""
     family = create_sssp_family()
     parameters = create_sssp_parameters(uuid=family.uuid).store().attributes
     structure = create_structure(site_kind_names=['Ar', 'He', 'Ne'])
@@ -311,7 +311,7 @@ def test_get_cutoffs(clear_db, create_sssp_family, create_sssp_parameters, creat
 
 
 def test_get_pseudos(clear_db, create_sssp_family, create_sssp_parameters, create_structure):
-    """Test the `SsspFamily.get_pseudos` method."""
+    """Test the `UpfFamily.get_pseudos` method."""
     family = create_sssp_family()
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #26 

The functionality provided by the `SsspFamily` is very useful but can
currently, by design choice, only be used for actual SSSP configurations.
The original idea of the plugin and `SsspFamily` is to not make it
easier for peopl to work with the SSSP but also make it less likely that
incorrect SSSP configurations are used.

However, there is still a common use case for UPF families that are not
strict SSSP configurations. Therefore, we generalize it to the new
plugin `UpfFamily` which represents a generic family of UPF files. The
`SsspFamily` then simply is a subclass as it just imposes additional
constraints.

The idea is that the `SsspFamily` can only be used for SSSP
configurations and all other use cases will employ the `UpfFamily`
plugin instead. Note that it will be difficult to prevent people from
using the `SsspFamily` group for non-SSSP families, but there will never
be a way to prevent this. Instead we will simply not provide a command
line interface to create `SsspFamily` instances from anything other than
the official resources from the Materials Cloud Archive entry.